### PR TITLE
fix(routing): click on slotted element

### DIFF
--- a/src/app-shell/clickevent-handler.ts
+++ b/src/app-shell/clickevent-handler.ts
@@ -23,12 +23,15 @@ export const clickEventHandler =
     }
 
     // support Shadow DOM
-    let anchor: HTMLAnchorElement | null = e.composedPath()[0] as HTMLAnchorElement | null ;
+    let anchor: HTMLAnchorElement | null | undefined = e.composedPath()[0] as HTMLAnchorElement | undefined ;
 
     if (!anchor) return;
 
     if (anchor.tagName !== "A") {
       anchor = anchor.closest("a");
+      if (!anchor) {
+        anchor = e.composedPath().find((target) => target instanceof Element && target.tagName === 'A') as HTMLAnchorElement | undefined;
+      }
       if (!anchor) return;
     }
 


### PR DESCRIPTION
the routing clickevent-handler just handle clicks on a child element of an anchor even if its slotted (eg.image in a link-card)