### PR TITLE
fix: header menu display on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,9 +293,19 @@
           margin-inline: 5px;
         }
         header {
-          padding: 1rem .5rem;
+          padding: .5rem;
+        }
+        header h1 {
+          flex-grow: 1;
+          text-align: center;
+        }
+        header spacer {
+          flex-grow: 2;
         }
         .header__menu {
+          flex-direction: column;
+          justify-content: space-around;
+          align-items: flex-end;
           gap: .5rem;
         }
       }

--- a/src/app-shell/routing/routed-actions.ts
+++ b/src/app-shell/routing/routed-actions.ts
@@ -7,7 +7,7 @@ export class AppRoutedActions extends LitElement {
   static override styles = [
     css`
       :host {
-        display: block;
+        display: var(--host-display, none);
       }
     `,
   ];
@@ -21,6 +21,11 @@ export class AppRoutedActions extends LitElement {
   ]);
 
   override render() {
-    return this.routing.routeTemplate ?? ``;
+    let hostDisplay = 'none';
+    if (this.routing.routeTemplate) {
+      hostDisplay = 'block'
+    }
+    this.style.setProperty('--host-display', hostDisplay);
+    return this.routing.routeTemplate;
   }
 }


### PR DESCRIPTION
improve the styles for the header items on small screens by:

1. only displaying the routed-actions if there are any (to avoid unecessary gaps)
2. using a flex column direction instead of wrap
3. adding small spaces around the title